### PR TITLE
Support Linux hosts in besiege_cli, including screen recording, and retry torn v4 telemetry reads

### DIFF
--- a/control/README.md
+++ b/control/README.md
@@ -171,9 +171,12 @@ telemetry delivery or a stable gait.
 `read_sample(timeout=0.05)` and `read_bulk_batch(timeout=0.05)` return a
 consistent commit or raise `SnapshotUnavailableError` for transient publication
 contention. They retain marker/buffer/sequence validation and use bounded
-backoff. Stable invalid payloads, unsupported versions, and permanent I/O
-errors fail immediately. A changed marker is checked before decoding an
-abandoned buffer; it is not evidence that the current committed frame is corrupt.
+backoff. A marker or buffer caught mid-rewrite (empty, or not yet decodable)
+is retried within the read budget; an empty file at the deadline is reported as
+`SnapshotUnavailableError`, while data that still does not decode at the
+deadline raises the codec error itself. Permanent I/O errors fail immediately.
+A changed marker is checked before decoding an abandoned buffer; it is not
+evidence that the current committed frame is corrupt.
 
 `next_sample`, `next_bulk_batch`, `wait_until_running`, and `wait_until_applied`
 retry contention within their own overall deadline. Controllers should use

--- a/control/besiege_cli/bootstrap.py
+++ b/control/besiege_cli/bootstrap.py
@@ -58,6 +58,10 @@ LAUNCHER_SANDBOX = "LONE ORB"
 SMOKE_HOLD_SECONDS = 15.0
 LAUNCHER_CONTROLLER_TIMEOUT = 1200.0
 
+# Platforms the one-command setup runs on. Windows is the reference desktop
+# install; Linux is the headless server target.
+SUPPORTED_SYSTEMS = ("Windows", "Linux")
+
 STAGE_PENDING = "pending"
 STAGE_RUNNING = "running"
 STAGE_PASSED = "passed"
@@ -434,11 +438,13 @@ def run_bootstrap(
         write_report(path=report_path, report=report)
 
     try:
-        if platform.system() != "Windows":
+        system = platform.system()
+        if system not in SUPPORTED_SYSTEMS:
             raise BootstrapError(
-                f"BuildArena setup only supports Windows. Detected platform: {platform.system()}."
+                f"BuildArena setup supports {', '.join(SUPPORTED_SYSTEMS)}. "
+                f"Detected platform: {system}."
             )
-        report.add(Stage(name="windows", status=STAGE_PASSED, message="Windows host."))
+        report.add(Stage(name="platform", status=STAGE_PASSED, message=f"{system} host."))
 
         if besiege_data_override is not None:
             besiege_data = normalize_besiege_data(raw=besiege_data_override)

--- a/control/besiege_cli/cli.py
+++ b/control/besiege_cli/cli.py
@@ -33,7 +33,7 @@ from .machine import (
 from .manifest import purge_mod_data
 from .orchestrator import BesiegeOrchestrator, OrchestratorTimeoutError
 from .paths import datacache_dir, mod_data_dir, resolve_besiege_data, resolve_channel_catalog
-from .process import find_besiege_pids
+from .process import BESIEGE_PROCESS_NAME, find_besiege_pids
 from .recorder import is_recording, start_recording, stop_recording
 from .run import DEFAULT_RUN_HOLD_SECONDS, add_run_parser
 from .session import ensure_game, ensure_sandbox, quit_game
@@ -203,7 +203,7 @@ def cmd_dump_channels(args: argparse.Namespace) -> int:
 def cmd_quit(args: argparse.Namespace) -> int:
     orchestrator, _ = _orchestrator(args)
     if not find_besiege_pids():
-        print("No running Besiege.exe process found; nothing to quit.")
+        print(f"No running {BESIEGE_PROCESS_NAME} process found; nothing to quit.")
         return 0
     result = quit_game(orchestrator=orchestrator, timeout=args.timeout, poll_interval=args.poll_interval)
     print(f"Besiege quit result: {result}")

--- a/control/besiege_cli/paths.py
+++ b/control/besiege_cli/paths.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import platform
 from pathlib import Path
 
 # Mod identity and the ModIO data folder name come from the single Python
@@ -44,16 +45,35 @@ def resolve_besiege_data(besiege_data: str | Path | None) -> Path:
     return path
 
 
+# Besiege ships a native binary per platform. Windows is the reference
+# install; Linux is the headless target and uses the Unity standalone name.
+BESIEGE_EXE_BY_SYSTEM = {
+    "Windows": "Besiege.exe",
+    "Linux": "Besiege.x86_64",
+}
+
+
+def besiege_exe_name(system: str | None = None) -> str:
+    resolved = platform.system() if system is None else system
+    name = BESIEGE_EXE_BY_SYSTEM.get(resolved)
+    if name is None:
+        raise RuntimeError(
+            f"No Besiege executable name is known for platform {resolved!r}. "
+            f"Supported: {', '.join(sorted(BESIEGE_EXE_BY_SYSTEM))}."
+        )
+    return name
+
+
 def besiege_install_root(besiege_data: Path) -> Path:
     root = besiege_data.parent
-    exe = root / "Besiege.exe"
+    exe = root / besiege_exe_name()
     if not exe.is_file():
-        raise FileNotFoundError(f"Besiege.exe not found next to Besiege_Data: {exe}")
+        raise FileNotFoundError(f"{exe.name} not found next to Besiege_Data: {exe}")
     return root
 
 
 def besiege_exe(besiege_data: Path) -> Path:
-    return besiege_install_root(besiege_data) / "Besiege.exe"
+    return besiege_install_root(besiege_data) / besiege_exe_name()
 
 
 def resolve_channel_catalog(catalog: str | Path | None = None) -> Path:

--- a/control/besiege_cli/process.py
+++ b/control/besiege_cli/process.py
@@ -1,43 +1,131 @@
 from __future__ import annotations
 
+import os
+import platform
+import shlex
 import subprocess
 from pathlib import Path
 
-from .paths import BESIEGE_STEAM_APP_ID
+from .paths import BESIEGE_STEAM_APP_ID, besiege_exe_name
 
-BESIEGE_PROCESS_NAME = "Besiege.exe"
+# Optional launch override. When set, this exact command line is run instead
+# of the game binary. Headless Linux hosts need it: the game still requires an
+# X display (Xvfb) and, on machines with many cores, a wrapper that limits the
+# core count Unity sees. Keeping that host-specific knowledge in an env var
+# leaves this module portable.
+LAUNCH_COMMAND_ENV = "BESIEGE_LAUNCH_COMMAND"
+
+
+def _default_process_name() -> str:
+    try:
+        return besiege_exe_name()
+    except RuntimeError:
+        return "Besiege.exe"
+
+
+# Kept as a module constant for callers and log messages.
+BESIEGE_PROCESS_NAME = _default_process_name()
+
+
+class UnsupportedPlatformError(RuntimeError):
+    """The host OS has no implementation for this process operation."""
+
+
+def steam_launch_available() -> bool:
+    """Whether asking the local Steam client to launch the game can work.
+
+    Headless Linux servers generally have no Steam client, and its login UI
+    cannot be driven without a GPU. Callers check this to skip straight to a
+    direct binary launch instead of waiting out a launch timeout.
+    """
+    system = platform.system()
+    if system == "Windows":
+        return True
+    if system == "Linux":
+        from shutil import which
+
+        return which("steam") is not None or which("xdg-open") is not None
+    return False
 
 
 def launch_via_steam() -> None:
     """Ask the local Steam client to launch Besiege by its confirmed app id.
 
-    Uses the OS URI handler (via `cmd /c start`) rather than shelling out to
-    steam.exe directly, since Steam's own URI protocol handler is what
-    actually owns update-checking/DRM before the game process starts.
+    Uses the OS URI handler rather than shelling out to steam.exe directly,
+    since Steam's own URI protocol handler is what actually owns
+    update-checking/DRM before the game process starts.
     """
-    subprocess.Popen(
-        ["cmd", "/c", "start", "", f"steam://rungameid/{BESIEGE_STEAM_APP_ID}"],
-        shell=False,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+    system = platform.system()
+    uri = f"steam://rungameid/{BESIEGE_STEAM_APP_ID}"
+    if system == "Windows":
+        subprocess.Popen(
+            ["cmd", "/c", "start", "", uri],
+            shell=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return
+    if system == "Linux":
+        from shutil import which
+
+        opener = which("steam") or which("xdg-open")
+        if opener is None:
+            raise UnsupportedPlatformError(
+                "No Steam client or xdg-open on this host; launch the game binary directly."
+            )
+        argv = [opener, uri] if opener.endswith("xdg-open") else [opener, uri]
+        subprocess.Popen(
+            argv,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        return
+    raise UnsupportedPlatformError(f"Steam launch is not implemented for {system}.")
 
 
 def launch_via_exe(besiege_root: Path) -> None:
-    exe = besiege_root / BESIEGE_PROCESS_NAME
+    """Start the game binary directly.
+
+    ``BESIEGE_LAUNCH_COMMAND`` takes precedence when set, so a headless host
+    can point at its own wrapper script (virtual display, core limiting, mod
+    loader injection) without this module knowing about any of it.
+    """
+    override = os.environ.get(LAUNCH_COMMAND_ENV, "").strip()
+    if override:
+        subprocess.Popen(
+            shlex.split(override),
+            cwd=str(besiege_root),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        return
+
+    exe = besiege_root / besiege_exe_name()
     if not exe.is_file():
-        raise FileNotFoundError(f"{BESIEGE_PROCESS_NAME} not found: {exe}")
-    subprocess.Popen([str(exe)], cwd=str(besiege_root))
+        raise FileNotFoundError(f"{exe.name} not found: {exe}")
+    if platform.system() == "Windows":
+        subprocess.Popen([str(exe)], cwd=str(besiege_root))
+        return
+    subprocess.Popen(
+        [str(exe)],
+        cwd=str(besiege_root),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
 
 
-def find_besiege_pids() -> list[int]:
-    """Return PIDs of running Besiege.exe processes via tasklist.
+def _find_pids_windows() -> list[int]:
+    """Return PIDs of running Besiege processes via tasklist.
 
     Avoids taking a dependency on psutil for a single-purpose PID lookup;
     tasklist is a stock Windows tool.
     """
+    name = besiege_exe_name("Windows")
     result = subprocess.run(
-        ["tasklist", "/FI", f"IMAGENAME eq {BESIEGE_PROCESS_NAME}", "/FO", "CSV", "/NH"],
+        ["tasklist", "/FI", f"IMAGENAME eq {name}", "/FO", "CSV", "/NH"],
         capture_output=True,
         text=True,
         check=True,
@@ -49,7 +137,7 @@ def find_besiege_pids() -> list[int]:
             continue
         fields = [field.strip('"') for field in line.split('","')]
         fields[0] = fields[0].lstrip('"')
-        if fields and fields[0] == BESIEGE_PROCESS_NAME and len(fields) >= 2:
+        if fields and fields[0] == name and len(fields) >= 2:
             try:
                 pids.append(int(fields[1]))
             except ValueError:
@@ -57,5 +145,55 @@ def find_besiege_pids() -> list[int]:
     return pids
 
 
+def _find_pids_linux() -> list[int]:
+    """Return PIDs of this user's running Besiege processes, read from /proc.
+
+    Only this user's processes count. Shared research machines can have other
+    people running the same game, and killing someone else's session would be
+    a real loss of work.
+
+    ``/proc/<pid>/comm`` is truncated to 15 characters by the kernel, which
+    the current binary name fits inside; the prefix comparison keeps a longer
+    future name working.
+    """
+    name = besiege_exe_name("Linux")
+    truncated = name[:15]
+    uid = os.getuid()
+    pids: list[int] = []
+    for entry in Path("/proc").iterdir():
+        if not entry.name.isdigit():
+            continue
+        try:
+            if entry.stat().st_uid != uid:
+                continue
+            comm = (entry / "comm").read_text(encoding="utf-8", errors="replace").strip()
+        except OSError:
+            continue
+        if comm == name or comm == truncated:
+            pids.append(int(entry.name))
+    return sorted(pids)
+
+
+def find_besiege_pids() -> list[int]:
+    system = platform.system()
+    if system == "Windows":
+        return _find_pids_windows()
+    if system == "Linux":
+        return _find_pids_linux()
+    raise UnsupportedPlatformError(f"Process lookup is not implemented for {system}.")
+
+
 def force_kill(pid: int) -> None:
-    subprocess.run(["taskkill", "/PID", str(pid), "/F"], check=True)
+    system = platform.system()
+    if system == "Windows":
+        subprocess.run(["taskkill", "/PID", str(pid), "/F"], check=True)
+        return
+    if system == "Linux":
+        import signal
+
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+        return
+    raise UnsupportedPlatformError(f"Force kill is not implemented for {system}.")

--- a/control/besiege_cli/recorder.py
+++ b/control/besiege_cli/recorder.py
@@ -1,9 +1,10 @@
 """Screen recording of the Besiege window via the bundled imageio-ffmpeg binary.
 
-Capture pipeline: gdigrab grabs the Besiege window, ffmpeg scales/pads to the
-target resolution and encodes H.264 at a capped bitrate. The recording is
-written to a .part.mkv first (Matroska stays playable after a hard process
-kill, unlike a non-finalized mp4) and remuxed to the final .mp4 on stop.
+Capture pipeline: gdigrab grabs the Besiege window on Windows (x11grab grabs
+the X display named by DISPLAY on Linux), ffmpeg scales/pads to the target
+resolution and encodes H.264 at a capped bitrate. The recording is written to
+a .part.mkv first (Matroska stays playable after a hard process kill, unlike a
+non-finalized mp4) and remuxed to the final .mp4 on stop.
 
 The recorder is split across processes: start_recording() may be called by
 one CLI invocation (start-sim) and stop_recording() by another (stop-sim),
@@ -16,6 +17,7 @@ from __future__ import annotations
 import ctypes
 import json
 import os
+import signal
 import subprocess
 import time
 from pathlib import Path
@@ -75,6 +77,34 @@ def restore_capture_window(window_title: str, *, timeout: float = 3.0) -> bool:
     )
 
 
+def _capture_input_args(fps: int, window_title: str) -> list[str]:
+    """ffmpeg input for the current platform.
+
+    Windows: gdigrab by exact window title. Linux: x11grab of the whole X
+    screen (root window) named by DISPLAY; in a headless X server sized to the
+    game resolution that is exactly the game window, a larger screen only adds
+    borders. A missing DISPLAY is an explicit error rather than a silent black
+    recording.
+    """
+    if os.name == "nt":
+        return ["-f", "gdigrab", "-framerate", str(fps), "-draw_mouse", "0", "-i", f"title={window_title}"]
+    display = os.environ.get("DISPLAY", "")
+    if not display:
+        raise RuntimeError("DISPLAY is not set; x11grab needs the X display the game window is on.")
+    return ["-f", "x11grab", "-framerate", str(fps), "-draw_mouse", "0", "-i", display]
+
+
+def _detach_kwargs() -> dict:
+    """Keep ffmpeg alive after the CLI process that started it exits.
+
+    start-sim and stop-sim are separate invocations; on POSIX a new session
+    also keeps a terminal Ctrl-C from reaching the capture.
+    """
+    if os.name == "nt":
+        return {"creationflags": subprocess.CREATE_NO_WINDOW}
+    return {"start_new_session": True}
+
+
 def start_recording(
     *,
     data_dir: Path,
@@ -105,10 +135,7 @@ def start_recording(
     command = [
         get_ffmpeg_exe(),
         "-y",
-        "-f", "gdigrab",
-        "-framerate", str(fps),
-        "-draw_mouse", "0",
-        "-i", f"title={window_title}",
+        *_capture_input_args(fps, window_title),
         "-vf", scale_pad,
         "-c:v", "libx264",
         "-preset", "veryfast",
@@ -124,17 +151,19 @@ def start_recording(
             stdin=subprocess.DEVNULL,
             stdout=log_handle,
             stderr=subprocess.STDOUT,
-            creationflags=subprocess.CREATE_NO_WINDOW,
+            **_detach_kwargs(),
         )
 
-    # ffmpeg exits within ~1s if the window title does not match or gdigrab
-    # cannot open the capture source; surface that instead of recording nothing.
+    # ffmpeg exits within ~1s if the window title does not match, the display
+    # cannot be opened, or the grab device is unavailable; surface that instead
+    # of recording nothing.
     time.sleep(1.5)
     if process.poll() is not None:
         log_tail = log_file.read_text(encoding="utf-8", errors="replace")[-2000:]
         raise RuntimeError(
-            f"ffmpeg exited immediately (code {process.returncode}); window title "
-            f"{window_title!r} probably not found.\n--- ffmpeg log tail ---\n{log_tail}"
+            f"ffmpeg exited immediately (code {process.returncode}); capture source "
+            f"(window {window_title!r} / DISPLAY {os.environ.get('DISPLAY', '')!r}) probably "
+            f"not found.\n--- ffmpeg log tail ---\n{log_tail}"
         )
 
     state_path.write_text(
@@ -153,6 +182,84 @@ def start_recording(
     return process.pid
 
 
+def _pid_alive(pid: int) -> bool:
+    """True while ``pid`` exists. Reaps it first if it is our own exited child, so
+    a zombie ffmpeg (start and stop in the same CLI process) does not count as
+    alive. A pid we may not signal belongs to another user: it exists, it is
+    not ours to touch."""
+    try:
+        reaped, _ = os.waitpid(pid, os.WNOHANG)
+        if reaped == pid:
+            return False
+    except ChildProcessError:
+        pass
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _is_capture_process(pid: int, part_file: Path) -> bool:
+    """Guard against pid reuse after a crash and against zombies left by a
+    non-reaping parent: only signal a process whose command line still is our
+    ffmpeg x11grab capture writing ``part_file`` (a zombie has an empty command
+    line). Linux reads /proc; other POSIX hosts skip the check."""
+    cmdline = Path("/proc") / str(pid) / "cmdline"
+    try:
+        argv = cmdline.read_bytes().split(b"\0")
+    except OSError:
+        return not cmdline.parent.exists()
+    return (
+        any(b"ffmpeg" in part for part in argv[:1])
+        and b"x11grab" in argv
+        and str(part_file).encode() in argv
+    )
+
+
+def _signal(pid: int, signum: int) -> bool:
+    try:
+        os.kill(pid, signum)
+    except (ProcessLookupError, PermissionError):
+        return False
+    return True
+
+
+def _terminate_capture(pid: int, part_file: Path, *, timeout: float = 10.0) -> None:
+    """Stop the ffmpeg capture started by an earlier (possibly different) CLI process.
+
+    Windows: hard kill is the only reliable cross-process stop for console
+    ffmpeg; the mkv container tolerates it (that is why we record to mkv).
+    POSIX: SIGINT lets ffmpeg write the container index, then SIGKILL if it
+    has not exited within ``timeout`` seconds. Every wait re-checks that the
+    pid is still our capture, so a reused pid is never signalled and a zombie
+    (parent that does not reap) never blocks the stop.
+    """
+    if os.name == "nt":
+        subprocess.run(["taskkill", "/PID", str(pid), "/F"], capture_output=True, check=False)
+        time.sleep(0.5)
+        return
+
+    def ours() -> bool:
+        return _is_capture_process(pid, part_file) and _pid_alive(pid)
+
+    if not ours() or not _signal(pid, signal.SIGINT):
+        return
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline and ours():
+        time.sleep(0.1)
+    if not ours() or not _signal(pid, signal.SIGKILL):
+        return
+    # SIGKILL has landed; nothing more gets written. Give the kernel a moment
+    # to tear the process down, then move on to the remux either way.
+    for _ in range(20):
+        if not ours():
+            return
+        time.sleep(0.1)
+
+
 def stop_recording(*, data_dir: Path) -> Path:
     """Stop the active capture, remux .part.mkv to the final .mp4, return its path."""
     state_path = recording_state_path(data_dir)
@@ -162,14 +269,7 @@ def stop_recording(*, data_dir: Path) -> Path:
     part_file = Path(state["part_file"])
     output = Path(state["output"])
 
-    # Hard kill is the only reliable cross-process stop for console ffmpeg on
-    # Windows; the mkv container tolerates it (that is why we record to mkv).
-    subprocess.run(
-        ["taskkill", "/PID", str(state["pid"]), "/F"],
-        capture_output=True,
-        check=False,
-    )
-    time.sleep(0.5)
+    _terminate_capture(int(state["pid"]), part_file)
 
     if not part_file.exists():
         state_path.unlink()

--- a/control/besiege_cli/session.py
+++ b/control/besiege_cli/session.py
@@ -13,7 +13,13 @@ from pathlib import Path
 
 from .orchestrator import BesiegeOrchestrator, OrchestratorTimeoutError
 from .paths import besiege_install_root
-from .process import find_besiege_pids, force_kill, launch_via_exe, launch_via_steam
+from .process import (
+    find_besiege_pids,
+    force_kill,
+    launch_via_exe,
+    launch_via_steam,
+    steam_launch_available,
+)
 
 DEFAULT_SANDBOX_LEVEL = "BARREN EXPANSE"
 
@@ -38,24 +44,29 @@ def ensure_game(*, orchestrator: BesiegeOrchestrator, besiege_data: Path, timeou
         return GameSession(already_running=True, launched=False)
     before = orchestrator.state_mtime()
     existing = set(find_besiege_pids())
-    print(
-        "Launching Besiege via Steam. After the window appears, ToolKit still "
-        "needs to finish loading — progress will print every 10s.",
-        flush=True,
-    )
-    launch_via_steam()
-    try:
-        orchestrator.wait_for_heartbeat(timeout=timeout, after_mtime=before)
-        return GameSession(already_running=False, launched=True)
-    except OrchestratorTimeoutError:
-        pass
-    new_pids = set(find_besiege_pids()) - existing
-    if new_pids:
-        raise OrchestratorTimeoutError(
-            f"Besiege PIDs {sorted(new_pids)} started but no mod heartbeat within {timeout}s "
-            "(mod failed to load? check output_log.txt)."
+    if steam_launch_available():
+        print(
+            "Launching Besiege via Steam. After the window appears, ToolKit still "
+            "needs to finish loading — progress will print every 10s.",
+            flush=True,
         )
-    print("Steam launch produced no process; launching Besiege.exe directly...")
+        launch_via_steam()
+        try:
+            orchestrator.wait_for_heartbeat(timeout=timeout, after_mtime=before)
+            return GameSession(already_running=False, launched=True)
+        except OrchestratorTimeoutError:
+            pass
+        new_pids = set(find_besiege_pids()) - existing
+        if new_pids:
+            raise OrchestratorTimeoutError(
+                f"Besiege PIDs {sorted(new_pids)} started but no mod heartbeat within {timeout}s "
+                "(mod failed to load? check output_log.txt)."
+            )
+        print("Steam launch produced no process; launching the game binary directly...")
+    else:
+        # Headless hosts have no Steam client, and waiting out the launch
+        # timeout before falling through would cost a minute of every run.
+        print("No Steam client on this host; launching the game binary directly.", flush=True)
     launch_via_exe(besiege_install_root(besiege_data))
     orchestrator.wait_for_heartbeat(timeout=timeout, after_mtime=before)
     return GameSession(already_running=False, launched=True)

--- a/control/besiege_cli/steam.py
+++ b/control/besiege_cli/steam.py
@@ -8,6 +8,7 @@ PublishedFileId; an empty ID is reported as unpublished, not as installed.
 from __future__ import annotations
 
 import re
+import platform
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -115,6 +116,9 @@ def _tokenize_vdf(text: str) -> list[str]:
 
 
 def steam_roots_from_registry() -> list[Path]:
+    if platform.system() != "Windows":
+        return []
+
     import winreg
 
     roots: list[Path] = []
@@ -136,12 +140,26 @@ def steam_roots_from_registry() -> list[Path]:
     return roots
 
 
-def candidate_steam_roots() -> list[Path]:
-    roots: list[Path] = list(steam_roots_from_registry())
-    for default_root in (
+# Default Steam install locations per platform. The Linux entries cover both
+# the modern XDG path and the two legacy ~/.steam symlinks; steamcmd installs
+# land under the same tree.
+DEFAULT_STEAM_ROOTS_BY_SYSTEM = {
+    "Windows": (
         Path(r"C:\Program Files (x86)\Steam"),
         Path(r"C:\Program Files\Steam"),
-    ):
+    ),
+    "Linux": (
+        Path.home() / ".local" / "share" / "Steam",
+        Path.home() / ".steam" / "steam",
+        Path.home() / ".steam" / "root",
+        Path.home() / "Steam",
+    ),
+}
+
+
+def candidate_steam_roots() -> list[Path]:
+    roots: list[Path] = list(steam_roots_from_registry())
+    for default_root in DEFAULT_STEAM_ROOTS_BY_SYSTEM.get(platform.system(), ()):
         if default_root.is_dir():
             roots.append(default_root)
     unique: list[Path] = []
@@ -344,8 +362,18 @@ def open_workshop_page(*, item_id: str | None = None) -> str:
     if resolved == "":
         return url
     steam_uri = f"steam://url/CommunityFilePage/{resolved}"
+    if platform.system() == "Windows":
+        argv = ["cmd", "/c", "start", "", steam_uri]
+    else:
+        from shutil import which
+
+        opener = which("xdg-open")
+        if opener is None:
+            # Nothing can open a browser here; the caller still prints the URL.
+            return url
+        argv = [opener, steam_uri]
     subprocess.Popen(
-        ["cmd", "/c", "start", "", steam_uri],
+        argv,
         shell=False,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,

--- a/control/controller_sdk/client.py
+++ b/control/controller_sdk/client.py
@@ -811,7 +811,10 @@ class ControllerClient:
         """Read one consistent commit; contention raises SnapshotUnavailableError.
 
         Use next_sample() to wait for a new frame over a longer deadline.
-        Invalid stable payloads and unsupported protocol versions fail immediately.
+        Files caught mid-rewrite (empty or not yet decodable) are retried within
+        ``timeout``; data that still does not decode at the deadline raises the
+        codec error itself, so stable bad data and unsupported protocol versions
+        fail within one read budget (default 50 ms), never as unavailability.
         """
         frame = read_committed(
             self.telemetry_publish_path,

--- a/control/controller_sdk/snapshot.py
+++ b/control/controller_sdk/snapshot.py
@@ -8,7 +8,30 @@ import time
 from pathlib import Path
 from typing import Any, Callable
 
+from .bulk_codec import BulkCodecError
 from .protocol import read_shared_bytes
+from .telemetry_codec import TelemetryCodecError
+
+# Hosts without shared-lock semantics (Linux) expose the marker and buffer
+# files mid-rewrite: empty while the mod truncates and rewrites them, or with
+# bytes that do not decode yet. Both are contention, not corruption, and are
+# retried within the caller's budget like a sharing violation on Windows. An
+# empty file is never a valid commit, so at the deadline it is reported as
+# SnapshotUnavailableError and outer waits keep waiting; bytes that still do
+# not decode at the deadline are real corruption or a version mismatch and the
+# last codec error itself is raised, never SnapshotUnavailableError.
+TRANSIENT_CODEC_ERRORS = (TelemetryCodecError, BulkCodecError)
+
+
+class _MidRewrite(Exception):
+    """A publication file was empty when read."""
+
+
+def _read_nonempty(path: Path, what: str) -> bytes:
+    data = read_shared_bytes(path)
+    if not data:
+        raise _MidRewrite(f"{what} is empty (being rewritten)")
+    return data
 
 
 class SnapshotUnavailableError(TimeoutError):
@@ -42,14 +65,16 @@ def read_committed(
     deadline = started + timeout
     attempt = 0
     reason = ""
+    codec_error: Exception | None = None
     stats["reads"] += 1
     try:
         while True:
             attempt += 1
+            codec_error = None
             try:
-                marker = decode_marker(read_shared_bytes(marker_path))
-                payload = read_shared_bytes(buffer_paths[marker.slot])
-                marker_after = decode_marker(read_shared_bytes(marker_path))
+                marker = decode_marker(_read_nonempty(marker_path, f"{label} marker"))
+                payload = _read_nonempty(buffer_paths[marker.slot], f"{label} buffer")
+                marker_after = decode_marker(_read_nonempty(marker_path, f"{label} marker"))
                 if marker_after != marker:
                     reason = f"{label} publish marker changed during the read"
                 else:
@@ -63,9 +88,16 @@ def read_committed(
                 if not retryable_io(exc):
                     raise
                 reason = f"{label} publication is temporarily unavailable: {exc}"
+            except _MidRewrite as exc:
+                reason = f"{label} publication is temporarily unavailable: {exc}"
+            except TRANSIENT_CODEC_ERRORS as exc:
+                codec_error = exc
+                reason = f"{label} publication did not decode: {exc}"
             stats["last_retry_reason"] = reason
             remaining = deadline - time.monotonic()
             if remaining <= 0:
+                if codec_error is not None:
+                    raise codec_error
                 stats["unavailable"] += 1
                 raise SnapshotUnavailableError(
                     f"No consistent {label} snapshot within {timeout:.3f}s "


### PR DESCRIPTION
## Summary

Makes `besiege_cli` run on Linux hosts and fixes two issues found while retesting the current `feat/control` there. Windows code paths are unchanged.

Three commits:

1. **Support Linux hosts in the besiege_cli platform layer** — platform-specific code stays in `paths.py`, `process.py`, `session.py`, `steam.py`, `bootstrap.py`: executable name per platform, `/proc`-based process discovery restricted to the current uid, SIGKILL instead of taskkill, a `BESIEGE_LAUNCH_COMMAND` hook for hosts without a Steam client (the Windows `cmd /c start` path is kept), `SUPPORTED_SYSTEMS = ("Windows", "Linux")`.
2. **Record the game window with x11grab on Linux hosts** — the recorder used gdigrab, `subprocess.CREATE_NO_WINDOW` and taskkill, so `--record` raised `AttributeError` on POSIX before ffmpeg started. Adds the POSIX equivalents next to the Windows ones: x11grab of `$DISPLAY`, `start_new_session`, SIGINT-then-SIGKILL stop with a liveness poll (the pid may belong to another CLI invocation) that re-checks on every poll that the pid is still this recording's ffmpeg x11grab process, so a reused pid (including another user's) is never signalled and a zombie left by a non-reaping parent cannot block the stop. Filter, encoder, `.part.mkv` and remux are unchanged.
3. **Retry mid-rewrite codec errors in read_committed within the budget** — a marker caught between truncate and write reads as 0 bytes (`Invalid BTM4 marker length 0`) and `read_committed()` only retried `OSError`, which failed an otherwise healthy run in `post_completion_hold`. An empty marker/buffer is now treated as contention: retried within the budget and reported as `SnapshotUnavailableError` at the deadline so outer waits keep waiting. Bytes that are present but do not decode are retried too, and if they still fail at the deadline the original codec error is raised (never `SnapshotUnavailableError`). README and the `read_sample` docstring describe the timing.

## Verification (Linux, no GPU, Xvfb + llvmpipe, ToolKit 2.0.9)

- `scripts/setup.py --non-interactive`: 15/15 stages pass (after installing `pillow`, see below).
- `run --record` on Reusable_Heavy_Launcher with rendering on: `result: ok`; `run.mp4` 37.7 s, 942 frames, 1920x1080 @ 25 fps.
- Cross-process `start-sim --record` → `stop-sim`: 15.2 s mp4, ffmpeg exits, state file removed.
- Four isolated instances running `run --record` concurrently: all ok, four distinct videos.
- Torn-read fix: synthetic tests (empty marker healing after 50 ms → frame returned; persistently empty → `SnapshotUnavailableError`; persistently undecodable bytes → `TelemetryCodecError` at the deadline; `timeout=0` → immediate); no recurrence in the managed runs after the fix.

## Found but not changed here

- `pillow` was removed from `pyproject.toml` but `buildarena/mesh_loader.py` still imports `PIL` at module level; `setup.py` crashes after the heartbeat on a fresh `uv sync`.
- Machines with a Pin block (id 57) fail the new KeyList binding check (`Unmapped runtime KeyList address`): the mod reports `key_list_channels: ["P"]` for Pin but `keylist_bindings.py` declares `57: {}`.
