### PR TITLE
Allow the offline TelemetryRecorder to sample at 100 Hz

### DIFF
--- a/control/besiege_cli/machine.py
+++ b/control/besiege_cli/machine.py
@@ -586,8 +586,8 @@ def prepare_machine_bsg(
     if isinstance(recorder_hz, bool) or not isinstance(recorder_hz, (int, float)):
         raise TypeError("recorder_hz must be numeric.")
     frequency = float(recorder_hz)
-    if frequency not in (10.0, 25.0, 50.0):
-        raise ValueError("recorder_hz must be one of 10, 25, or 50.")
+    if frequency not in (10.0, 25.0, 50.0, 100.0):
+        raise ValueError("recorder_hz must be one of 10, 25, 50, or 100.")
     output_path = Path(output_bsg)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     tree, _, _ = parse_bsg(source_bsg, catalog_path=None)

--- a/control/besiege_cli/run.py
+++ b/control/besiege_cli/run.py
@@ -1009,7 +1009,7 @@ def add_run_parser(subparsers: argparse._SubParsersAction, common_args) -> None:
     parser.add_argument(
         "--recorder-hz",
         type=int,
-        choices=(10, 25, 50),
+        choices=(10, 25, 50, 100),
         default=None,
         help="Offline TelemetryRecorder frequency. Recorder is always full-machine full (default: 25).",
     )


### PR DESCRIPTION
## Summary

Adds 100 Hz to the accepted values of `--recorder-hz` for the offline TelemetryRecorder. Two lines: the argparse `choices` in `control/besiege_cli/run.py` and the guard in `prepare_machine_bsg()` in `control/besiege_cli/machine.py`.

## Why

- The ToolKit's `RateGate` accepts any rate that maps to an integer number of physics frames. Besiege's fixed timestep is 0.01 s, so 100 Hz is exactly one sample per physics frame. The CLI list was stricter than the mod.
- One sample per physics frame is what you need to compare repeated runs of the same machine row by row. Runs of the same machine start moving on slightly different physics frames (the start event is paced by render frames), so at 25 Hz two runs can only be compared through interpolation; at 100 Hz they line up after shifting an integer number of rows.

## Verification

Managed `besiege_cli run --recorder-hz 100` on a Linux host with ToolKit 2.0.9:

- `telemetry_manifest.json`: `sample_rate_hz: 100`, `fixed_delta_time: 0.01`, `sample_interval_frames: 1`, `completed: true`; `run_status.json`: `result: ok`.
- A 15 s hold produced roughly 1600 samples per block (5-block machine: 7965 rows; 45-block machine: about 74k rows, 19 MB CSV).
- `load_session()`'s strict per-frame sample-period check passed on every run.
- Two runs that happened to start on the same physics frame were byte-identical for 1595 consecutive samples. Runs that started N frames apart matched after an N-row shift to within float32 noise (position residual around 1e-6 for the 5-block machine).
- `--recorder-hz 60` is still rejected by both argparse and `prepare_machine_bsg()`.

## Scope

- Live BAT4 telemetry (`--telemetry-hz`) and BAB4 bulk (`--bulk-hz`) are unchanged: those streams are written per sample and were not measured at 100 Hz.
- `configure-telemetry` (fixed 25 Hz) is unchanged.
